### PR TITLE
Fix (with most deprecated warnings) for Ruby 2.4.4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,11 +70,12 @@ _Requirements_
 * Ruby Interpreter - Get the [most recent version here](http://www.ruby-lang.org/en/). It is required to run the utility scripts outside of RMXP. You will need a version with the YAML and Zlib modules.
 * RPG Maker XP - For RMXP games
 * RPG Maker VX - For RMVX games
-* Windows XP - I believe this should work on Windows Vista or Windows 7 also. The only potential problem I forsee could be the batch file commands.
+* Windows - Tested on Windows 10
 * (Optional) Versioning System - If you want to keep track of versions of your exported data, you will need a versioning system like [Git](http://git-scm.com/), [Mercurial](http://mercurial.selenic.com/), or [Subversion](http://subversion.apache.org/).
 
 _Setup_
 
+* Install the `listen` and `wdm` gems (though this should be done automatically).
 * Download the latest version of RMXP Plugin System in this repo (as a ZIP at top of this page or cloning using Git).
 * Back up your project (just copy it somewhere for safe-keeping).
 * Extract the archive into a directory or your choice. NOTE: If you wish to use this in multiple projects, it is best to create a folder in the same directory as your projects and extract to that folder. Just make sure to update the PLUGIN_SYSTEM_ROOT and RMXP_PROJECT_ROOT variables set in Game.bat (see below default Game.bat). A sample directory hierarchy is below:

--- a/addons.rb
+++ b/addons.rb
@@ -6,19 +6,11 @@
 
 #-------------------------------------------------------------------------------------
 # This change to Hash is critical if we want to version YAML files.  By default, the
-# order of hash keys is not guaranteed.  This change modifies the Hash#to_yaml method
-# to sort the hash based on key before emitting the YAML for it.
+# order of hash keys is not guaranteed.
 #-------------------------------------------------------------------------------------
 class Hash
-  # Replacing the to_yaml function so it'll serializes hashes sorted (by their keys)
-  def to_yaml( opts = {} )
-    YAML::dump( object_id, opts ) do |out|
-      out.map( taguri, to_yaml_style ) do |map|
-        sort.each do |k, v|   # <-- here's my addition (the 'sort')
-          map.add( k, v )
-        end
-      end
-    end
+  def encode_with coder
+    coder.represent_map nil, self.sort.to_h
   end
 end
 

--- a/addons.rb
+++ b/addons.rb
@@ -12,7 +12,7 @@
 class Hash
   # Replacing the to_yaml function so it'll serializes hashes sorted (by their keys)
   def to_yaml( opts = {} )
-    YAML::quick_emit( object_id, opts ) do |out|
+    YAML::dump( object_id, opts ) do |out|
       out.map( taguri, to_yaml_style ) do |map|
         sort.each do |k, v|   # <-- here's my addition (the 'sort')
           map.add( k, v )

--- a/common.rb
+++ b/common.rb
@@ -14,7 +14,7 @@ require 'zlib'
 # Add bin directory to the Ruby search path
 #$LOAD_PATH << "C:/bin"
 
-require 'addons'
+require_relative 'addons'
 
 require 'yaml'
 
@@ -138,7 +138,7 @@ end
 #----------------------------------------------------------------------------
 def data_file_exported?(filename)
   exported_filename = $PROJECT_DIR + '/' + $YAML_DIR + '/' + File.basename(filename, File.extname(filename)) + ".yaml"
-  return File.exists?( exported_filename )
+  return File.exist?( exported_filename )
 end
 
 #----------------------------------------------------------------------------
@@ -157,7 +157,7 @@ end
 #----------------------------------------------------------------------------
 def load_startup_time(delete_file = false)
   t = nil
-  if File.exists?( $PROJECT_DIR + '/' + $TIME_LOG_FILE )
+  if File.exist?( $PROJECT_DIR + '/' + $TIME_LOG_FILE )
     File.open( $PROJECT_DIR + '/' + $TIME_LOG_FILE, "r+" ) do |infile|
       t = Marshal.load( infile )
     end

--- a/plugin_base.rb
+++ b/plugin_base.rb
@@ -9,8 +9,8 @@
 #  be run before or after, as well as methods for calling on startup and on
 #  shutdown of the system.
 #===============================================================================
-require 'rgl/adjacency'
-require 'rgl/topsort.rb'
+require_relative 'rgl/adjacency'
+require_relative 'rgl/topsort.rb'
 
 class PluginBase
   @@plugins = []
@@ -21,7 +21,7 @@ class PluginBase
   end
 
 protected
-  def self.register( klass )
+  def self.register(klass)
     @@plugins << klass
   end
 

--- a/plugins/data_importer_exporter.rb
+++ b/plugins/data_importer_exporter.rb
@@ -33,7 +33,7 @@ class DataImporterExporter < PluginBase
     print_separator(true)
     
     # Check if the input directory exists
-    if not (File.exists? $INPUT_DIR and File.directory? $INPUT_DIR)
+    if not (File.exist? $INPUT_DIR and File.directory? $INPUT_DIR)
       puts "Input directory #{$INPUT_DIR} does not exist."
       puts "Nothing to import...skipping import."
       puts
@@ -41,7 +41,7 @@ class DataImporterExporter < PluginBase
     end
  
     # Check if the output directory exists
-    if not (File.exists? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
+    if not (File.exist? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
       puts "Error: Output directory #{$OUTPUT_DIR} does not exist."
       puts "Hint: Check that the $DATA_DIR variable in paths.rb is set to the correct path."
       puts
@@ -122,14 +122,14 @@ class DataImporterExporter < PluginBase
     $STARTUP_TIME = load_startup_time || Time.now
  
     # Check if the input directory exists
-    if not (File.exists? $INPUT_DIR and File.directory? $INPUT_DIR)
+    if not (File.exist? $INPUT_DIR and File.directory? $INPUT_DIR)
       puts "Error: Input directory #{$INPUT_DIR} does not exist."
       puts "Hint: Check that the $DATA_DIR variable in paths.rb is set to the correct path."
       exit
     end
  
     # Create the output directory if it doesn't exist
-    if not (File.exists? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
+    if not (File.exist? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
       recursive_mkdir( $OUTPUT_DIR )
     end
  

--- a/plugins/script_importer_exporter.rb
+++ b/plugins/script_importer_exporter.rb
@@ -31,7 +31,7 @@ class ScriptImporterExporter < PluginBase
     print_separator(true)
  
     # Check if the input directory exists
-    if not (File.exists? $INPUT_DIR and File.directory? $INPUT_DIR)
+    if not (File.exist? $INPUT_DIR and File.directory? $INPUT_DIR)
       puts_verbose "Input directory #{$INPUT_DIR} does not exist."
       puts_verbose "Nothing to import...skipping import."
       puts_verbose
@@ -39,7 +39,7 @@ class ScriptImporterExporter < PluginBase
     end
  
     # Create the output directory if it doesn't exist
-    if not (File.exists? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
+    if not (File.exist? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
       puts "Error: Output directory #{$OUTPUT_DIR} does not exist."
       puts "Hint: Check that the data_dir config option in config.yaml is set correctly."
       puts
@@ -49,7 +49,7 @@ class ScriptImporterExporter < PluginBase
     start_time = Time.now
  
     # Import the RGSS scripts from Ruby files
-    if File.exists?($INPUT_DIR + $EXPORT_DIGEST_FILE)
+    if File.exist?($INPUT_DIR + $EXPORT_DIGEST_FILE)
       # Load the export digest
       digest = []
       i = 0
@@ -71,19 +71,19 @@ class ScriptImporterExporter < PluginBase
       # Create the scripts data structure
       scripts = []
       #for i in (0..digest.length-1)
-      digest.each_index do |i|
+      digest.each_index do |index|
         # Get the time starting the deflate
         deflate_start_time = Time.now
         
-        scripts[i] = []
-        scripts[i][0] = digest[i][0]
-        scripts[i][1] = digest[i][1]
-        scripts[i][2] = ""
-        if digest[i][2].upcase != "EMPTY"
+        scripts[index] = []
+        scripts[index][0] = digest[index][0]
+        scripts[index][1] = digest[index][1]
+        scripts[index][2] = ""
+        if digest[index][2].upcase != "EMPTY"
           begin
-            scriptname = $INPUT_DIR + "/" + digest[i][2]
+            scriptname = $INPUT_DIR + "/" + digest[index][2]
             File.open(scriptname, File::RDONLY) do |infile|
-              scripts[i][2] = infile.read
+              scripts[index][2] = infile.read
             end
           rescue Errno::ENOENT
             puts "ERROR:      No such file or directory - #{scriptname.gsub!('//','/')}.\n" +
@@ -93,13 +93,13 @@ class ScriptImporterExporter < PluginBase
           num_exported += 1
         end
         # Perform the deflate on the compressed script
-        scripts[i][2] = Zlib::Deflate.deflate(scripts[i][2])
+        scripts[index][2] = Zlib::Deflate.deflate(scripts[index][2])
         # Calculate the elapsed time for the deflate
         deflate_elapsed_time = Time.now - deflate_start_time
         # Build a log string
-        str =  "Imported #{digest[i][2].ljust($FILENAME_WIDTH)}(#{num_exported.to_s.rjust(3, '0')}/#{num_scripts.to_s.rjust(3, '0')})"
+        str =  "Imported #{digest[index][2].ljust($FILENAME_WIDTH)}(#{num_exported.to_s.rjust(3, '0')}/#{num_scripts.to_s.rjust(3, '0')})"
         str += "         #{deflate_elapsed_time} seconds" if deflate_elapsed_time > 0.0
-        puts_verbose str if digest[i][2].upcase != "EMPTY"
+        puts_verbose str if digest[index][2].upcase != "EMPTY"
       end
  
       # Dump the scripts data structure to the RM's Script file
@@ -131,18 +131,18 @@ class ScriptImporterExporter < PluginBase
     $STARTUP_TIME = load_startup_time || Time.now
  
     # Check if the input directory exists
-    if not (File.exists? $INPUT_DIR and File.directory? $INPUT_DIR)
+    if not (File.exist? $INPUT_DIR and File.directory? $INPUT_DIR)
       puts "Error: Input directory #{$INPUT_DIR} does not exist."
       puts "Hint: Check that the data_dir path in config.yaml is set to the correct path."
       exit
     end
  
     # Create the output directory if it doesn't exist
-    if not (File.exists? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
+    if not (File.exist? $OUTPUT_DIR and File.directory? $OUTPUT_DIR)
       recursive_mkdir( $OUTPUT_DIR )
     end
  
-    if (not file_modified_since?($INPUT_DIR + "Scripts.#{$DATA_TYPE}", $STARTUP_TIME)) and (File.exists?($SCRIPTS_DIR + "/" + $EXPORT_DIGEST_FILE))
+    if (not file_modified_since?($INPUT_DIR + "Scripts.#{$DATA_TYPE}", $STARTUP_TIME)) and (File.exist?($SCRIPTS_DIR + "/" + $EXPORT_DIGEST_FILE))
       puts_verbose "No RGSS scripts need to be exported."
       puts_verbose
       return

--- a/rgl/adjacency.rb
+++ b/rgl/adjacency.rb
@@ -12,7 +12,7 @@
 # Set.  This can be configured by the client, however, when an AdjacencyGraph
 # is created.
 
-require 'rgl/mutable'
+require_relative 'mutable'
 require 'set'
 
 module RGL
@@ -26,7 +26,7 @@ module RGL
     #  RGL::DirectedAdjacencyGraph[1,2, 2,3, 2,4, 4,5].edges.to_a.to_s =>
     #    "(1-2)(2-3)(2-4)(4-5)"
 
-    def self.[] (*a)
+    def self.[](*a)
       result = new
       0.step(a.size-1, 2) { |i| result.add_edge(a[i], a[i+1]) }
       result
@@ -38,7 +38,7 @@ module RGL
     #
     # If other graphs are passed as parameters their vertices and edges are
     # added to the new graph.
-    def initialize (edgelist_class = Set, *other_graphs)
+    def initialize(edgelist_class = Set, *other_graphs)
       @edgelist_class = edgelist_class
       @vertice_dict   = Hash.new
       other_graphs.each do |g|
@@ -57,11 +57,11 @@ module RGL
 
     # Iterator for the keys of the vertice list hash.
 
-    def each_vertex (&b)
+    def each_vertex(&b)
       @vertice_dict.each_key(&b)
     end
 
-    def each_adjacent (v, &b)			# :nodoc:
+    def each_adjacent(v, &b)			# :nodoc:
       adjacency_list = (@vertice_dict[v] or
         raise NoVertexError, "No vertex #{v}.")
       adjacency_list.each(&b)
@@ -76,7 +76,7 @@ module RGL
     # Complexity is O(1), because the vertices are kept in a Hash containing
     # as values the lists of adjacent vertices of _v_.
 
-    def has_vertex? (v)
+    def has_vertex?(v)
       @vertice_dict.has_key?(v)
     end
 
@@ -86,7 +86,7 @@ module RGL
     # ---
     # MutableGraph interface.
 
-    def has_edge? (u, v)
+    def has_edge?(u, v)
       has_vertex?(u) and @vertice_dict[u].include?(v)
     end
 
@@ -95,13 +95,13 @@ module RGL
     # If the vertex is already in the graph (using eql?), the method does
     # nothing.
 
-    def add_vertex (v)
+    def add_vertex(v)
       @vertice_dict[v] ||= @edgelist_class.new
     end
 
     # See MutableGraph#add_edge.
 
-    def add_edge (u, v)
+    def add_edge(u, v)
       add_vertex(u)                         # ensure key
       add_vertex(v)                         # ensure key
       basic_add_edge(u, v)
@@ -109,7 +109,7 @@ module RGL
 
     # See MutableGraph#remove_vertex.
 
-    def remove_vertex (v)
+    def remove_vertex(v)
       @vertice_dict.delete(v)
           
       # remove v from all adjacency lists
@@ -119,7 +119,7 @@ module RGL
 
     # See MutableGraph::remove_edge.
 
-    def remove_edge (u, v)
+    def remove_edge(u, v)
       @vertice_dict[u].delete(v) unless @vertice_dict[u].nil?
     end
 
@@ -134,7 +134,7 @@ module RGL
 
     protected
 
-    def basic_add_edge (u, v)
+    def basic_add_edge(u, v)
       @vertice_dict[u].add(v)
     end
 
@@ -152,14 +152,14 @@ module RGL
         
     # Also removes (v,u)
 
-    def remove_edge (u, v)
+    def remove_edge(u, v)
       super
       @vertice_dict[v].delete(u) unless @vertice_dict[v].nil?
     end
 
     protected
 
-    def basic_add_edge (u,v)
+    def basic_add_edge(u,v)
       super
       @vertice_dict[v].add(u)			# Insert backwards edge
     end

--- a/rgl/base.rb
+++ b/rgl/base.rb
@@ -3,7 +3,7 @@
 # Module RGL defines the namespace for all modules and classes of the graph
 # library. The main module is RGL::Graph which defines the abstract behavior of
 # all graphs in the library.
-require 'rgl/enumerable_ext'
+require_relative 'enumerable_ext'
 
 RGL_VERSION = "0.4.0"
 
@@ -32,7 +32,7 @@ module RGL
       end
 
       # Create a new DirectedEdge with source _a_ and target _b_.
-      def initialize (a,b)
+      def initialize(a,b)
         @source, @target = a,b
       end
       
@@ -103,14 +103,14 @@ module RGL
     # The each_vertex iterator defines the set of vertices. This method must be
     # defined by concrete graph classes. It defines the BGL VertexListGraph
     # concept.
-    def each_vertex () # :yields: v
+    def each_vertex() # :yields: v
       raise NotImplementedError
     end
 
     # The each_adjacent iterator defines the out edges of vertex _v_. This
     # method must be defined by concrete graph classes. Its defines the BGL
     # IncidenceGraph concept.
-    def each_adjacent (v) # :yields: v
+    def each_adjacent(v) # :yields: v
       raise NotImplementedError
     end
 
@@ -121,7 +121,7 @@ module RGL
     # can be implemented using each_vertex and each_adjacent. However for
     # undirected graph the function is inefficient because we must not yield
     # (v,u) if we already visited edge (u,v).
-    def each_edge (&block)
+    def each_edge(&block)
       if directed?
         each_vertex { |u|
           each_adjacent(u) { |v| yield u,v }
@@ -165,7 +165,7 @@ module RGL
     end
 
     # Returns an array of vertices adjacent to vertex _v_.
-    def adjacent_vertices (v)
+    def adjacent_vertices(v)
       r = []
       each_adjacent(v) {|u| r << u}
       r
@@ -173,7 +173,7 @@ module RGL
 
     # Returns the number of out-edges (for directed graphs) or the number of
 		# incident edges (for undirected graphs) of vertex _v_.
-    def out_degree (v)
+    def out_degree(v)
       r = 0
       each_adjacent(v) { |u| r += 1}
       r

--- a/rgl/mutable.rb
+++ b/rgl/mutable.rb
@@ -1,6 +1,6 @@
 # mutable.rb
 
-require 'rgl/base'
+require_relative 'base'
 
 module RGL
 
@@ -13,7 +13,7 @@ module RGL
     # Add a new vertex _v_ to the graph.  If the vertex is already in the
     # graph (tested via eql?), the method does nothing.
 
-    def add_vertex (v)
+    def add_vertex(v)
       raise NotImplementedError
     end
 
@@ -25,13 +25,13 @@ module RGL
     # will appear in the out-edges of v.  Put another way, v will be adjacent
     # to u and u will be adjacent to v. 
 
-    def add_edge (u, v)
+    def add_edge(u, v)
       raise NotImplementedError
     end
 
     # Add all objects in _a_ to the vertex set.
 
-    def add_vertices (*a)
+    def add_vertices(*a)
       a.each { |v| add_vertex v }
     end
 
@@ -39,7 +39,7 @@ module RGL
     # array can be both two-element arrays or instances of DirectedEdge or
     # UnDirectedEdge. 
 
-    def add_edges (*edges)
+    def add_edges(*edges)
       edges.each { |edge| add_edge(edge[0], edge[1]) }
     end
 
@@ -49,7 +49,7 @@ module RGL
     # Postcondition: num_vertices is one less, _v_ no longer appears in the
     # vertex set of the graph, and there no edge with source or target _v_.
 
-    def remove_vertex (v)
+    def remove_vertex(v)
       raise NotImplementedError
     end
 
@@ -59,14 +59,14 @@ module RGL
     # Precondition: u and v are vertices in the graph.
     # Postcondition: (u,v) is no longer in the edge set for g.
 
-    def remove_edge (u, v)
+    def remove_edge(u, v)
       raise NotImplementedError
     end
 
     # Remove all vertices specified by the array a from the graph by calling
     # remove_vertex.
 
-    def remove_vertices (*a)
+    def remove_vertices(*a)
       a.each { |v| remove_vertex v }
     end
 

--- a/rgl/topsort.rb
+++ b/rgl/topsort.rb
@@ -1,6 +1,6 @@
 # topsort.rb
 
-require 'rgl/traversal'
+require_relative 'traversal'
 
 module RGL
 
@@ -18,7 +18,7 @@ module RGL
 
     include GraphIterator
 
-    def initialize (g)
+    def initialize(g)
       super(g)
       set_to_begin
     end

--- a/rgl/traversal.rb
+++ b/rgl/traversal.rb
@@ -9,9 +9,9 @@
 # Visitor[http://www.boost.org/libs/graph/doc/visitor_concepts.html] Concepts
 # in a slightly modified fashion (especially for the RGL::DFSIterator).
 
-require 'rgl/base'
+require_relative 'base'
 require 'rubygems' rescue LoadError # If using stream gem
-require 'stream'
+require_relative '../stream'
 
 module RGL
 
@@ -20,7 +20,7 @@ module RGL
     attr_accessor :graph
 
     # Creates a new GraphWrapper on _graph_.
-    def initialize (graph)
+    def initialize(graph)
       @graph = graph
     end
 
@@ -71,7 +71,7 @@ module RGL
 
     # Create a new GraphVisitor on _graph_.
 
-    def initialize (graph)
+    def initialize(graph)
       super graph
       reset
     end
@@ -84,7 +84,7 @@ module RGL
 
     # Returns true if vertex _v_ is colored :BLACK (i.e. finished).
 
-    def finished_vertex? (v)
+    def finished_vertex?(v)
       @color_map[v] == :BLACK
     end
  
@@ -97,19 +97,19 @@ module RGL
     # After the distance_map is attached, the visitor has a new method
     # distance_to_root, which answers the distance to the start vertex.
 
-    def attach_distance_map (map = Hash.new(0))
+    def attach_distance_map(map = Hash.new(0))
       @dist_map = map
 
       class << self
 
-        def handle_tree_edge (u, v)
+        def handle_tree_edge(u, v)
           super
           @dist_map[v] = @dist_map[u] + 1
         end
 
         # Answer the distance to the start vertex.
 
-        def distance_to_root (v)
+        def distance_to_root(v)
           @dist_map[v]
         end
 
@@ -118,20 +118,20 @@ module RGL
 
     # Shall we follow the edge (u,v); i.e. v has color :WHITE
 
-    def follow_edge? (u, v)			# :nodoc:
+    def follow_edge?(u, v)			# :nodoc:
       @color_map[v] == :WHITE
     end
 
     # == Visitor Event Points
 
-    def self.def_event_handler (m)
+    def self.def_event_handler(m)
       params = m =~ /edge/ ? "u,v" : "u"
       self.class_eval %{
-        def handle_#{m} (#{params})
+        def handle_#{m}(#{params})
           @#{m}_event_handler.call(#{params}) if defined? @#{m}_event_handler
         end
 
-        def set_#{m}_event_handler (&b)
+        def set_#{m}_event_handler(&b)
           @#{m}_event_handler = b
         end
       }
@@ -166,7 +166,7 @@ module RGL
 
     # Create a new BFSIterator on _graph_, starting at vertex _start_.
 
-    def initialize (graph, start=graph.detect{ |x| true })
+    def initialize(graph, start=graph.detect{ |x| true })
       super(graph)
       @start_vertex = start
       set_to_begin
@@ -227,7 +227,7 @@ module RGL
 
     # Returns a BFSIterator, starting at vertex _v_.
 
-    def bfs_iterator (v = self.detect { |x| true})
+    def bfs_iterator(v = self.detect { |x| true})
       BFSIterator.new(self, v)
     end
 
@@ -235,8 +235,8 @@ module RGL
     # starting at _v_.  This method uses the tree_edge_event of BFSIterator
     # to record all tree edges of the search tree in the result.
 
-    def bfs_search_tree_from (v)
-      require 'rgl/adjacency'
+    def bfs_search_tree_from(v)
+      require_relative 'adjacency'
       bfs  = bfs_iterator(v)
       tree = DirectedAdjacencyGraph.new
       bfs.set_tree_edge_event_handler { |from, to|
@@ -289,7 +289,7 @@ module RGL
 
     # Returns a DFSIterator staring at vertex _v_.
 
-    def dfs_iterator (v = self.detect { |x| true })
+    def dfs_iterator(v = self.detect { |x| true })
       DFSIterator.new(self, v)
     end
 
@@ -297,7 +297,7 @@ module RGL
     # it is called on each _finish_vertex_ event.  See
     # strongly_connected_components for an example usage.
 
-    def depth_first_search (vis = DFSVisitor.new(self), &b)
+    def depth_first_search(vis = DFSVisitor.new(self), &b)
       each_vertex do |u|
         unless vis.finished_vertex?(u)
           vis.handle_start_vertex(u)
@@ -309,7 +309,7 @@ module RGL
     # Start a depth first search at vertex _u_.  The block _b_ is called on
     # each finish_vertex event.
 
-    def depth_first_visit (u, vis = DFSVisitor.new(self), &b)
+    def depth_first_visit(u, vis = DFSVisitor.new(self), &b)
       vis.color_map[u] = :GRAY
       vis.handle_examine_vertex(u)
       each_adjacent(u) { |v|

--- a/rmxp/rgss.rb
+++ b/rmxp/rgss.rb
@@ -7,6 +7,6 @@
 #    of RMXP's .rxdata files.
 #===============================================================================
 
-require 'rmxp/rgss_internal'
-require 'rmxp/rgss_rpg'
-require 'rmxp/rgss_mod'
+require_relative 'rgss_internal'
+require_relative 'rgss_rpg'
+require_relative 'rgss_mod'

--- a/start_rmvx.rb
+++ b/start_rmvx.rb
@@ -24,6 +24,16 @@ require 'rmvx/rgss2'
 require 'common'
 require 'plugin_base'
 
+begin
+    require 'listen'
+rescue LoadError
+    puts "Installing listen and wdm gems, make sure you have internet connectivity"
+    `gem install listen`
+    `gem install wdm`
+    puts "Installation Successful! Please restart the script!"
+    exit
+end
+
 #######################################
 #        LOCAL METHODS
 #######################################
@@ -89,6 +99,21 @@ puts "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 puts "!!!DO NOT CLOSE THIS COMMAND WINDOW!!!"
 puts "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 puts_verbose
+
+# P.S. too bored to refactor :(
+listener = Listen.to($PROJECT_DIR + $DATA_DIR) do |modified, added, removed|
+    # Get the list of plugins in the shutdown order
+    plugins = get_plugin_order( :on_exit )
+
+    # Create each plugin object
+    plugins.collect! {|plugin| eval( plugin + ".new" )}
+
+    # Execute each plugin's on_exit event
+    plugins.each do |plugin|
+        plugin.on_exit
+    end
+end
+listener.start
 
 # Start RMXP
 command = 'START /B /WAIT /D"' + $PROJECT_DIR + '" Game.rvproj'

--- a/start_rmxp.rb
+++ b/start_rmxp.rb
@@ -19,9 +19,9 @@ end
 
 $DATA_TYPE = "rxdata"
 
-require 'rmxp/rgss'
-require 'common'
-require 'plugin_base'
+require_relative 'rmxp/rgss'
+require_relative 'common'
+require_relative 'plugin_base'
 
 #######################################
 #        LOCAL METHODS
@@ -36,7 +36,7 @@ require 'plugin_base'
 # event:  The symbol representing the event.  Valid values are
 #         :on_start and :on_shutdown
 #=====================================================================
-def get_plugin_order( event )
+def get_plugin_order(event)
 	if event == :on_start
 	  return PluginBase::get_startup_plugin_order
 	else
@@ -65,7 +65,7 @@ plugins.each do |plugin|
   plugin_path = "plugins\\" + plugin
   File.open( plugin_path, "r+" ) do |infile|
     code = infile.read( File.size( plugin_path ) )
-    eval( code )
+    eval(code)
   end
 end
 

--- a/start_rmxp.rb
+++ b/start_rmxp.rb
@@ -23,6 +23,17 @@ require_relative 'rmxp/rgss'
 require_relative 'common'
 require_relative 'plugin_base'
 
+begin
+    require 'listen'
+    require 'wdm'
+rescue LoadError
+    puts "Installing listen and wdm gems, make sure you have internet connectivity"
+    `gem install listen`
+    `gem install wdm`
+    puts "Installation Successful! Please restart the script!"
+    exit
+end
+
 #######################################
 #        LOCAL METHODS
 #######################################
@@ -88,6 +99,21 @@ puts "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 puts "!!!DO NOT CLOSE THIS COMMAND WINDOW!!!"
 puts "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 puts_verbose
+
+# P.S. too bored to refactor :(
+listener = Listen.to($PROJECT_DIR + $DATA_DIR) do |modified, added, removed|
+    # Get the list of plugins in the shutdown order
+    plugins = get_plugin_order( :on_exit )
+
+    # Create each plugin object
+    plugins.collect! {|plugin| eval( plugin + ".new" )}
+
+    # Execute each plugin's on_exit event
+    plugins.each do |plugin|
+        plugin.on_exit
+    end
+end
+listener.start
 
 # Start RMXP
 command = 'START /B /WAIT /D"' + $PROJECT_DIR + '" Game.rxproj'

--- a/stream.rb
+++ b/stream.rb
@@ -180,7 +180,7 @@ module Stream
 
 	# Create a new IntervalStream with upper bound _stop_. stop - 1 is the last
 	# element. By default _stop_ is zero which means that the stream is empty.
-	def initialize (stop=0)
+	def initialize(stop=0)
 	  @stop = stop - 1
 	  set_to_begin
 	end
@@ -192,7 +192,7 @@ module Stream
 	def set_to_begin; @pos = -1; end
 
 	# Increment the upper bound by incr.
-	def increment_stop (incr=1); @stop += incr; end
+	def increment_stop(incr=1); @stop += incr; end
 
 	def basic_forward; @pos += 1; end
 	def basic_backward;  @pos -= 1; @pos + 1; end
@@ -211,7 +211,7 @@ module Stream
 	attr_reader :wrapped_stream
 
 	# Create a new WrappedStream wrapping the Stream _otherStream_.
-	def initialize (otherStream)
+	def initialize(otherStream)
 	  @wrapped_stream = otherStream
 	end
 
@@ -240,7 +240,7 @@ module Stream
 
 	# Create a new FilteredStream wrapping _otherStream_ and selecting all its
 	# elements which satisfy the condition defined by the block_filter_.
-	def initialize (otherStream, &filter)
+	def initialize(otherStream, &filter)
 	  super otherStream
 	  @filter = filter
 	  @positionHolder = IntervalStream.new
@@ -308,7 +308,7 @@ module Stream
 	# Create a reversing wrapper for the reversable stream _otherStream_. If
 	# _otherStream_ does not support backward moving a NotImplementedError is signaled
 	# on the first backward move.
-	def initialize (otherStream)
+	def initialize(otherStream)
 	  super otherStream
 	  set_to_begin
 	end
@@ -342,7 +342,7 @@ module Stream
 	##
 	# Creates a new MappedStream wrapping _otherStream_ which calls the block
 	# _mapping_ on each move.
-	def initialize (otherStream, &mapping)
+	def initialize(otherStream, &mapping)
 	  super otherStream
 	  @mapping = mapping
 	end
@@ -367,7 +367,7 @@ module Stream
 	private :streamOfStreams
 
 	# Creates a new ConcatenatedStream wrapping the stream of streams _streamOfStreams_.
-	def initialize (streamOfStreams)
+	def initialize(streamOfStreams)
 	  super
 	  set_to_begin
 	end
@@ -467,7 +467,7 @@ module Stream
 	#
 	# If a block is given to new, than it is called with the new ImplicitStream
 	# stream as parameter letting the client overwriting the default blocks.
-	def initialize (otherStream=nil)
+	def initialize(otherStream=nil)
 	  if otherStream
 		@wrapped_stream = otherStream
 		@at_beginning_proc = proc {otherStream.at_beginning?}
@@ -509,7 +509,7 @@ module Stream
   ##
   # Return a Stream::FilteredStream which iterates over all my elements
   # satisfying the condition specified  by the block.
-  def filtered (&block); FilteredStream.new(self,&block); end
+  def filtered(&block); FilteredStream.new(self,&block); end
 
   # Create a Stream::ReversedStream wrapper on self.
   def reverse; ReversedStream.new self; end
@@ -517,7 +517,7 @@ module Stream
   # Create a Stream::MappedStream wrapper on self. Instead of returning the stream
   # element on each move, the value of calling _mapping_ is returned instead. See
   # Stream::MappedStream for examples.
-  def collect (&mapping); MappedStream.new(self, &mapping); end
+  def collect(&mapping); MappedStream.new(self, &mapping); end
 
   # Create a Stream::ConcatenatedStream on self, which must be a stream of streams.
   def concatenate; ConcatenatedStream.new self; end
@@ -529,19 +529,19 @@ module Stream
   #    [i,-i].create_stream
   #  }.
   #  s.to_a ==> [1, -1, 2, -2, 3, -3]
-  def concatenate_collected (&mapping); self.collect(&mapping).concatenate; end
+  def concatenate_collected(&mapping); self.collect(&mapping).concatenate; end
 
   # Create a Stream::ConcatenatedStream by concatenatating the receiver and _otherStream_
   #
   #  (%w(a b c).create_stream + [4,5].create_stream).to_a ==> ["a", "b", "c", 4, 5]
-  def + (otherStream)
+  def +(otherStream)
 	[self, otherStream].create_stream.concatenate
   end
 
   # Create a Stream::ImplicitStream which wraps the receiver stream by modifying one
   # or more basic methods of the receiver. As an example the method remove_first uses
   # #modify to create an ImplicitStream which filters the first element away.
-  def modify (&block); ImplicitStream.new(self, &block); end
+  def modify(&block); ImplicitStream.new(self, &block); end
 
   # Returns a Stream::ImplicitStream wrapping a Stream::FilteredStream, which
   # eliminates the first element of the receiver.


### PR DESCRIPTION
Fix all warnings due to whitespace
Replace `require` with `require_relative`
Replace `File.exists?` with `File.exist?`
Some other things

~~Implementing `to_yaml` is deprecated, not fixed since I don't know ruby enough to find an easy way around this~~